### PR TITLE
SRT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,10 @@ There are a couple of audio encoding configurations:
 - `ogg/flac` sends FLAC audio in an OGG wrapper on ~1200 kbit/s. This is the highest possible uncompressed audio.
 
 ### Experimental SRT streaming
-In the future we would like to use SRT for streaming. This is integrated on experimental basis now. The server side needs to be there too. It's being built in https://github.com/oszuidwest/liquidsoap-ubuntu/tree/srt-upstream
+In the future we would like to use SRT for streaming. This is integrated on experimental basis now. The server side needs to be there too. For now Liquidsoap is not ready to receive SRT streams, but you can user the SRT sample tools. For example start a server on macOS and save the stream to `test.mp3`:
+
+```
+brew install srt
+srt-live-transmit "srt://:5001?mode=listener&streamid=studio&passphrase=foxtrot-uniform-charlie-kilo" file://con > test.mp3
+```
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rpi-audio-encoder
 This repository contains the audio streaming software for [ZuidWest FM](https://www.zuidwestfm.nl/) in the Netherlands. It uses a Rapsberry Pi 4 and a [HiFiBerry Digi+ I/O](https://www.hifiberry.com/shop/boards/hifiberry-digi-io/) as audio input. As encoder ffmpeg is used, which is combined with Supervisor to manage the process via a webinterface. It sends audio to an Icecast2 server.
 
-This encoder resides in the studio and is connected to an Optimod. It can stream to any Icecast server. Our server software to complete the audio stack can be found in [this respository](https://github.com/oszuidwest/liquidsoap-ubuntu).
+This encoder resides in the studio and is connected to an Optimod. It can stream to any Icecast or SRT server. Our server software to complete the audio stack can be found in [this respository](https://github.com/oszuidwest/liquidsoap-ubuntu).
 
 <img src="https://user-images.githubusercontent.com/6742496/211200145-7b11db44-8c6e-4674-8163-55c706f45054.jpg" width=40% height=40%>
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ brew install srt
 srt-live-transmit "srt://:5001?mode=listener&streamid=studio&passphrase=foxtrot-uniform-charlie-kilo" file://con > test.mp3
 ```
 
+For more about SRT:
+- SRT overview: https://datatracker.ietf.org/meeting/107/materials/slides-107-dispatch-srt-overview-01
+- SRT deployment guide: https://www.vmix.com/download/srt_alliance_deployment_guide.pdf
+- SRT 101 video: https://www.youtube.com/watch?v=e5YLItNG3lA 

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ There are a couple of audio encoding configurations:
 - `ogg/vorbis` sends OGG Vorbis audio on 500 kbit/s. This is the highest quality ogg/vorbis possible.
 - `ogg/flac` sends FLAC audio in an OGG wrapper on ~1200 kbit/s. This is the highest possible uncompressed audio.
 
-### Todo: experiment with SRT streaming
-In the future we would like to use SRT for streaming. The server side needs to be there first. It's being built in https://github.com/oszuidwest/liquidsoap-ubuntu/tree/srt-upstream
+### Experimental SRT streaming
+In the future we would like to use SRT for streaming. This is integrated on experimental basis now. The server side needs to be there too. It's being built in https://github.com/oszuidwest/liquidsoap-ubuntu/tree/srt-upstream

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There are a couple of audio encoding configurations:
 - `ogg/flac` sends FLAC audio in an OGG wrapper on ~1200 kbit/s. This is the highest possible uncompressed audio.
 
 ### Experimental SRT streaming
-In the future we would like to use SRT for streaming. This is integrated on experimental basis now. The server side needs to be there too. For now Liquidsoap is not ready to receive SRT streams, but you can user the SRT sample tools. For example start a server on macOS and save the stream to `test.mp3`:
+In the future we would like to use SRT for streaming. This is integrated on experimental basis now. The server side needs to be there too. For now Liquidsoap (our server software) is not ready to receive SRT streams, but you can user the SRT sample tools. For example start a server on macOS and save the stream to `test.mp3`:
 
 ```
 brew install srt

--- a/install.sh
+++ b/install.sh
@@ -46,10 +46,16 @@ read -p "Choose a port for the web interface (default: 90) " WEB_PORT
 read -p "Choose a username for the web interface (default: admin) " WEB_USER
 read -p "Choose a password for the web interface (default: encoder) " WEB_PASSWORD
 read -p "Choose output format: mp2, mp3, ogg/vorbis, or ogg/flac (default: ogg/flac) " OUTPUT_FORMAT
+read -p "Choose output server: type 1 for Icecast, type 2 for SRT (default: 1)" OUTPUT_SERVER
 read -p "Hostname or IP address of Icecast or SRT server (default: localhost) " STREAM_HOST
 read -p "Port of Icecast or SRT server (default: 8080) " STREAM_PORT
 read -p "Password for Icecast or SRT server (default: hackme) " STREAM_PASSWORD
-read -p "Mountpoint of Icecast server (default: studio) - not needed for SRT " ICECAST_MOUNTPOINT #TODO: Put this behind a flag
+
+# Only ask for a mountpoint if the output server is Icecast
+if [ "$OUTPUT_SERVER" = "1" ]; then
+  read -p "Mountpoint of Icecast server (default: studio) " ICECAST_MOUNTPOINT
+fi
+
 
 # Set defaults
 DO_UPDATES=${DO_UPDATES:-y}
@@ -57,6 +63,7 @@ SAVE_OUTPUT=${SAVE_OUTPUT:-y}
 LOG_FILE=${LOG_FILE:-/var/log/ffmpeg/stream.log}
 LOG_ROTATION=${LOG_ROTATION:-y}
 OUTPUT_FORMAT=${OUTPUT_FORMAT:-ogg/flac}
+OUTPUT_SERVER=${OUTPUT_SERVER:-1}
 WEB_PORT=${WEB_PORT:-90}
 WEB_USER=${WEB_USER:-admin}
 WEB_PASSWORD=${WEB_PASSWORD:-encoder}
@@ -156,9 +163,12 @@ elif [ "$OUTPUT_FORMAT" = "ogg/flac" ]; then
   FF_OUTPUT_FORMAT='ogg'
 fi
 
-# WIP Set the ffmpeg output server based on the value of FF_OUTPUT_SERVER
-# icecast://source:$STREAM_PASSWORD@$STREAM_HOST:$STREAM_PORT/$ICECAST_MOUNTPOINT"
-# srt://$STREAM_HOST:$STREAM_PORT?pkt_size=1316"
+# Define output server for ffmpeg based on OUTPUT_SERVER
+if [ "$OUTPUT_SERVER" = "1" ]; then
+  FF_OUTPUT_SERVER='icecast://source:$STREAM_PASSWORD@$STREAM_HOST:$STREAM_PORT/$ICECAST_MOUNTPOINT"'
+else
+  FF_OUTPUT_SERVER='srt://$STREAM_HOST:$STREAM_PORT?pkt_size=1316'
+fi
 
 # Create the configuration file for supervisor
 cat << EOF > /etc/supervisor/conf.d/stream.conf

--- a/install.sh
+++ b/install.sh
@@ -90,6 +90,11 @@ if ! [[ "$LOG_FILE" =~ ^/.+/.+$ ]]; then
   exit 1
 fi
 
+if [ "$OUTPUT_SERVER" != "1" ] && [ "$OUTPUT_SERVER" != "2" ]; then
+  echo "Invalid value for OUTPUT_SERVER. Only '1' for Icecast or '2' for SRT are allowed."
+  exit 1
+fi
+
 if [ "$OUTPUT_FORMAT" != "mp2" ] && [ "$OUTPUT_FORMAT" != "mp3" ] && [ "$OUTPUT_FORMAT" != "ogg/vorbis" ] && [ "$OUTPUT_FORMAT" != "ogg/flac" ]; then
   echo "Invalid input for OUTPUT_FORMAT. Only 'mp2', 'mp3', 'ogg/vorbis', or 'ogg/flac' are allowed."
   exit 1
@@ -165,7 +170,7 @@ fi
 
 # Define output server for ffmpeg based on OUTPUT_SERVER
 if [ "$OUTPUT_SERVER" = "1" ]; then
-  FF_OUTPUT_SERVER='icecast://source:$STREAM_PASSWORD@$STREAM_HOST:$STREAM_PORT/$ICECAST_MOUNTPOINT"'
+  FF_OUTPUT_SERVER='icecast://source:$STREAM_PASSWORD@$STREAM_HOST:$STREAM_PORT/$ICECAST_MOUNTPOINT'
 else
   FF_OUTPUT_SERVER='srt://$STREAM_HOST:$STREAM_PORT?pkt_size=1316'
 fi

--- a/install.sh
+++ b/install.sh
@@ -50,11 +50,7 @@ read -p "Choose output server: type 1 for Icecast, type 2 for SRT (default: 1)" 
 read -p "Hostname or IP address of Icecast or SRT server (default: localhost) " STREAM_HOST
 read -p "Port of Icecast or SRT server (default: 8080) " STREAM_PORT
 read -p "Password for Icecast or SRT server (default: hackme) " STREAM_PASSWORD
-
-# Only ask for a mountpoint if the output server is Icecast
-if [ "$OUTPUT_SERVER" = "1" ]; then
-  read -p "Mountpoint of Icecast server (default: studio) " ICECAST_MOUNTPOINT
-fi
+read -p "Mountpoint for Icecast server or Stream ID for SRT server (default: studio) " STREAM_MOUNTPOINT
 
 # Set defaults
 DO_UPDATES=${DO_UPDATES:-y}
@@ -69,7 +65,7 @@ WEB_PASSWORD=${WEB_PASSWORD:-encoder}
 STREAM_HOST=${STREAM_HOST:-localhost}
 STREAM_PORT=${STREAM_PORT:-8000}
 STREAM_PASSWORD=${STREAM_PASSWORD:-hackme}
-ICECAST_MOUNTPOINT=${ICECAST_MOUNTPOINT:-studio}
+STREAM_MOUNTPOINT=${STREAM_MOUNTPOINT:-studio}
 
 # Perform validation on input
 var_is_y_or_n "$DO_UPDATES" "$SAVE_OUTPUT" "$LOG_ROTATION"
@@ -169,9 +165,9 @@ fi
 
 # Define output server for ffmpeg based on OUTPUT_SERVER
 if [ "$OUTPUT_SERVER" = "1" ]; then
-  FF_OUTPUT_SERVER='icecast://source:$STREAM_PASSWORD@$STREAM_HOST:$STREAM_PORT/$ICECAST_MOUNTPOINT'
+  FF_OUTPUT_SERVER='icecast://source:$STREAM_PASSWORD@$STREAM_HOST:$STREAM_PORT/$STREAM_MOUNTPOINT'
 else
-  FF_OUTPUT_SERVER='srt://$STREAM_HOST:$STREAM_PORT?pkt_size=1316&mode=caller&transtype=live&streamid=$STREAM_PASSWORD&passphrase=foxtrot-uniform-charlie-kilo' #TODO: make passphrase not hardcoded
+  FF_OUTPUT_SERVER='srt://$STREAM_HOST:$STREAM_PORT?pkt_size=1316&mode=caller&transtype=live&streamid=$STREAM_MOUNTPOINT&passphrase=$STREAM_PASSWORD'
 fi
 
 # Create the configuration file for supervisor

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,6 @@ if [ "$OUTPUT_SERVER" = "1" ]; then
   read -p "Mountpoint of Icecast server (default: studio) " ICECAST_MOUNTPOINT
 fi
 
-
 # Set defaults
 DO_UPDATES=${DO_UPDATES:-y}
 SAVE_OUTPUT=${SAVE_OUTPUT:-y}
@@ -172,7 +171,7 @@ fi
 if [ "$OUTPUT_SERVER" = "1" ]; then
   FF_OUTPUT_SERVER='icecast://source:$STREAM_PASSWORD@$STREAM_HOST:$STREAM_PORT/$ICECAST_MOUNTPOINT'
 else
-  FF_OUTPUT_SERVER='srt://$STREAM_HOST:$STREAM_PORT?pkt_size=1316'
+  FF_OUTPUT_SERVER='srt://$STREAM_HOST:$STREAM_PORT?pkt_size=1316&mode=caller&streamid=$STREAM_PASSWORD&passphrase=foxtrot-uniform-charlie-kilo' #TODO: make passphrase not hardcoded
 fi
 
 # Create the configuration file for supervisor

--- a/install.sh
+++ b/install.sh
@@ -47,9 +47,9 @@ read -p "Choose a username for the web interface (default: admin) " WEB_USER
 read -p "Choose a password for the web interface (default: encoder) " WEB_PASSWORD
 read -p "Choose output format: mp2, mp3, ogg/vorbis, or ogg/flac (default: ogg/flac) " OUTPUT_FORMAT
 read -p "Hostname or IP address of Icecast server (default: localhost) " ICECAST_HOST
-read -p "Port of Icecast server (default: 8080) " ICECAST_PORT
-read -p "Password for Icecast server (default: hackme) " ICECAST_PASSWORD
-read -p "Mountpoint of Icecast server (default: studio) " ICECAST_MOUNTPOINT
+read -p "Port of Icecast or SRT server (default: 8080) " ICECAST_PORT
+read -p "Password for Icecast or SRT server (default: hackme) " ICECAST_PASSWORD
+read -p "Mountpoint of Icecast server (default: studio) - not needed for SRT " ICECAST_MOUNTPOINT #TODO: Put this behind a flag
 
 # Set defaults
 DO_UPDATES=${DO_UPDATES:-y}
@@ -159,7 +159,7 @@ fi
 # Create the configuration file for supervisor
 cat << EOF > /etc/supervisor/conf.d/stream.conf
   [program:encoder]
-  command=bash -c "sleep 30 && ffmpeg -f alsa -channels 2 -sample_rate 48000 -hide_banner -re -y -i default:CARD=sndrpihifiberry -codec:a $FF_AUDIO_CODEC -content_type $FF_CONTENT_TYPE -vn -f $FF_OUTPUT_FORMAT icecast://source:$ICECAST_PASSWORD@$ICECAST_HOST:$ICECAST_PORT/$ICECAST_MOUNTPOINT"
+  command=bash -c "sleep 30 && ffmpeg -f alsa -channels 2 -sample_rate 48000 -hide_banner -re -y -i default:CARD=sndrpihifiberry -codec:a $FF_AUDIO_CODEC -content_type $FF_CONTENT_TYPE -vn -f $FF_OUTPUT_FORMAT srt://$ICECAST_HOST:$ICECAST_PORT?pkt_size=1316"
   # Sleep 30 seconds before starting ffmpeg because the network or audio might not be available after a reboot. Works for now, should dig in the exact cause in the future.
   autostart=true
   autorestart=true

--- a/install.sh
+++ b/install.sh
@@ -171,7 +171,7 @@ fi
 if [ "$OUTPUT_SERVER" = "1" ]; then
   FF_OUTPUT_SERVER='icecast://source:$STREAM_PASSWORD@$STREAM_HOST:$STREAM_PORT/$ICECAST_MOUNTPOINT'
 else
-  FF_OUTPUT_SERVER='srt://$STREAM_HOST:$STREAM_PORT?pkt_size=1316&mode=caller&streamid=$STREAM_PASSWORD&passphrase=foxtrot-uniform-charlie-kilo' #TODO: make passphrase not hardcoded
+  FF_OUTPUT_SERVER='srt://$STREAM_HOST:$STREAM_PORT?pkt_size=1316&mode=caller&transtype=live&streamid=$STREAM_PASSWORD&passphrase=foxtrot-uniform-charlie-kilo' #TODO: make passphrase not hardcoded
 fi
 
 # Create the configuration file for supervisor


### PR DESCRIPTION
Use SRT as upstream method instead of the aging Icecast protocol. 

This implements SRT besides Icecast, which is still used in legacy production units.

- SRT overview: https://datatracker.ietf.org/meeting/107/materials/slides-107-dispatch-srt-overview-01
- SRT deployment guide: https://www.vmix.com/download/srt_alliance_deployment_guide.pdf