### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Bash linter
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/rpi-audio-encoder/security/code-scanning/2](https://github.com/oszuidwest/rpi-audio-encoder/security/code-scanning/2)

To fix this problem, add an explicit top-level `permissions` block to the workflow specification in .github/workflows/lint.yml. The block should be placed near the top of the file (immediately below `name:` or `on:`). For a linter workflow that simply checks out code and runs static analysis, the minimal permission of `contents: read` is sufficient, as the workflow does not need to modify repository contents, issues, or pull requests.

Edit the region above or immediately after `on:` to add the following:

```yaml
permissions:
  contents: read
```

No imports or additional logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
